### PR TITLE
feat: add dedicated Grafy page with historical sensor data charts

### DIFF
--- a/apps/garden_fe/src/app/dashboard/grafy/page.tsx
+++ b/apps/garden_fe/src/app/dashboard/grafy/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { BarChart3 } from 'lucide-react';
+
+import { useRooms } from '@/hooks/useRooms';
+import { useChartData, type TimeRange } from '@/hooks/useChartData';
+import { TemperatureChart } from '@/components/charts/TemperatureChart';
+import { HumidityChart } from '@/components/charts/HumidityChart';
+import { SoilMoistureChart } from '@/components/charts/SoilMoistureChart';
+import { WaterLevelChart } from '@/components/charts/WaterLevelChart';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { SensorReading } from '@/types/api';
+
+const TIME_RANGES: { value: TimeRange; label: string }[] = [
+  { value: '24h', label: '24 hodin' },
+  { value: '7d', label: '7 dni' },
+  { value: '30d', label: '30 dni' },
+  { value: 'custom', label: 'Vlastni' },
+];
+
+function formatTime(dateStr: string, range: TimeRange): string {
+  const date = new Date(dateStr);
+  if (range === '24h') {
+    return date.toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' });
+  }
+  if (range === '7d') {
+    return date.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric' }) +
+      ' ' + date.toLocaleTimeString('cs-CZ', { hour: '2-digit', minute: '2-digit' });
+  }
+  return date.toLocaleDateString('cs-CZ', { day: 'numeric', month: 'numeric' });
+}
+
+function toChartData(readings: SensorReading[], key: keyof SensorReading, range: TimeRange) {
+  return readings.map((r) => ({
+    time: formatTime(r.createdAt, range),
+    value: r[key] as number,
+  }));
+}
+
+export default function GrafyPage() {
+  const { data: rooms, loading: roomsLoading } = useRooms();
+  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
+  const [timeRange, setTimeRange] = useState<TimeRange>('24h');
+  const [customFrom, setCustomFrom] = useState('');
+  const [customTo, setCustomTo] = useState('');
+
+  const roomId = selectedRoomId ?? (rooms.length > 0 ? rooms[0].id : null);
+
+  const { data: sensorData, loading: dataLoading } = useChartData(
+    roomId,
+    timeRange,
+    customFrom,
+    customTo
+  );
+
+  const chartHeight = 300;
+  const isLoading = roomsLoading || dataLoading;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-gray-900">
+          <BarChart3 className="h-7 w-7 text-green-600" />
+          Grafy
+        </h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Historicka data ze senzoru
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="flex flex-wrap items-end gap-4 p-4">
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-gray-700">Mistnost</label>
+            <select
+              className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+              value={roomId ?? ''}
+              onChange={(e) => setSelectedRoomId(e.target.value)}
+              disabled={roomsLoading}
+            >
+              {rooms.map((room) => (
+                <option key={room.id} value={room.id}>
+                  {room.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-gray-700">Obdobi</label>
+            <div className="flex gap-1">
+              {TIME_RANGES.map((tr) => (
+                <Button
+                  key={tr.value}
+                  variant={timeRange === tr.value ? 'default' : 'outline'}
+                  size="sm"
+                  className={
+                    timeRange === tr.value
+                      ? 'bg-green-600 text-white hover:bg-green-700'
+                      : ''
+                  }
+                  onClick={() => setTimeRange(tr.value)}
+                >
+                  {tr.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          {timeRange === 'custom' && (
+            <div className="flex items-end gap-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Od</label>
+                <input
+                  type="date"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+                  value={customFrom}
+                  onChange={(e) => setCustomFrom(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Do</label>
+                <input
+                  type="date"
+                  className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+                  value={customTo}
+                  onChange={(e) => setCustomTo(e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {[...Array(4)].map((_, i) => (
+            <Skeleton key={i} className="h-[380px] rounded-xl" />
+          ))}
+        </div>
+      ) : !roomId ? (
+        <Card>
+          <CardContent className="flex h-[300px] items-center justify-center text-sm text-gray-500">
+            Zadna mistnost k zobrazeni
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          <TemperatureChart
+            data={toChartData(sensorData, 'temperature', timeRange)}
+            height={chartHeight}
+          />
+          <HumidityChart
+            data={toChartData(sensorData, 'humidity', timeRange)}
+            height={chartHeight}
+          />
+          <SoilMoistureChart
+            data={toChartData(sensorData, 'soilMoisture', timeRange)}
+            height={chartHeight}
+          />
+          <WaterLevelChart
+            data={toChartData(sensorData, 'waterLevel', timeRange)}
+            height={chartHeight}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/garden_fe/src/components/charts/SoilMoistureChart.tsx
+++ b/apps/garden_fe/src/components/charts/SoilMoistureChart.tsx
@@ -12,9 +12,10 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 interface SoilMoistureChartProps {
   data?: { time: string; value: number }[];
+  height?: number;
 }
 
-export function SoilMoistureChart({ data }: SoilMoistureChartProps) {
+export function SoilMoistureChart({ data, height = 200 }: SoilMoistureChartProps) {
   if (!data || data.length === 0) {
     return (
       <Card>
@@ -22,7 +23,7 @@ export function SoilMoistureChart({ data }: SoilMoistureChartProps) {
           <CardTitle className="text-base">Vlhkost pudy</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+          <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
             Zadna data ze senzoru
           </div>
         </CardContent>
@@ -36,7 +37,7 @@ export function SoilMoistureChart({ data }: SoilMoistureChartProps) {
         <CardTitle className="text-base">Vlhkost pudy</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={200}>
+        <ResponsiveContainer width="100%" height={height}>
           <AreaChart data={data}>
             <defs>
               <linearGradient id="soilGradient" x1="0" y1="0" x2="0" y2="1">

--- a/apps/garden_fe/src/components/charts/TemperatureChart.tsx
+++ b/apps/garden_fe/src/components/charts/TemperatureChart.tsx
@@ -12,9 +12,10 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
 interface TemperatureChartProps {
   data?: { time: string; value: number }[];
+  height?: number;
 }
 
-export function TemperatureChart({ data }: TemperatureChartProps) {
+export function TemperatureChart({ data, height = 200 }: TemperatureChartProps) {
   if (!data || data.length === 0) {
     return (
       <Card>
@@ -22,7 +23,7 @@ export function TemperatureChart({ data }: TemperatureChartProps) {
           <CardTitle className="text-base">Teplota</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+          <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
             Zadna data ze senzoru
           </div>
         </CardContent>
@@ -36,7 +37,7 @@ export function TemperatureChart({ data }: TemperatureChartProps) {
         <CardTitle className="text-base">Teplota</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={200}>
+        <ResponsiveContainer width="100%" height={height}>
           <AreaChart data={data}>
             <defs>
               <linearGradient id="tempGradient" x1="0" y1="0" x2="0" y2="1">

--- a/apps/garden_fe/src/components/charts/WaterLevelChart.tsx
+++ b/apps/garden_fe/src/components/charts/WaterLevelChart.tsx
@@ -10,17 +10,17 @@ import {
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 
-interface HumidityChartProps {
+interface WaterLevelChartProps {
   data?: { time: string; value: number }[];
   height?: number;
 }
 
-export function HumidityChart({ data, height = 200 }: HumidityChartProps) {
+export function WaterLevelChart({ data, height = 200 }: WaterLevelChartProps) {
   if (!data || data.length === 0) {
     return (
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Vlhkost</CardTitle>
+          <CardTitle className="text-base">Hladina vody</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-center justify-center text-sm text-muted-foreground" style={{ height }}>
@@ -34,15 +34,15 @@ export function HumidityChart({ data, height = 200 }: HumidityChartProps) {
   return (
     <Card>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base">Vlhkost</CardTitle>
+        <CardTitle className="text-base">Hladina vody</CardTitle>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={height}>
           <AreaChart data={data}>
             <defs>
-              <linearGradient id="humidityGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#14b8a6" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#14b8a6" stopOpacity={0} />
+              <linearGradient id="waterLevelGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#06b6d4" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#06b6d4" stopOpacity={0} />
               </linearGradient>
             </defs>
             <XAxis
@@ -56,17 +56,18 @@ export function HumidityChart({ data, height = 200 }: HumidityChartProps) {
               tickLine={false}
               axisLine={false}
               unit="%"
+              domain={[0, 100]}
             />
             <Tooltip
-              formatter={(val: any) => [`${val}%`, "Vlhkost"] as any}
+              formatter={(val: any) => [`${val}%`, "Hladina vody"] as any}
               contentStyle={{ borderRadius: 8, fontSize: 13 }}
             />
             <Area
               type="monotone"
               dataKey="value"
-              stroke="#14b8a6"
+              stroke="#06b6d4"
               strokeWidth={2}
-              fill="url(#humidityGradient)"
+              fill="url(#waterLevelGradient)"
             />
           </AreaChart>
         </ResponsiveContainer>

--- a/apps/garden_fe/src/components/layout/Sidebar.tsx
+++ b/apps/garden_fe/src/components/layout/Sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Home, Leaf, Bell, Settings } from 'lucide-react';
+import { LayoutDashboard, Home, BarChart3, Bell, Settings } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
 const navItems = [
   { href: '/dashboard', label: 'Prehled', icon: LayoutDashboard },
   { href: '/dashboard/rooms', label: 'Mistnosti', icon: Home },
+  { href: '/dashboard/grafy', label: 'Grafy', icon: BarChart3 },
   { href: '/dashboard/notifications', label: 'Upozorneni', icon: Bell },
   { href: '/dashboard/settings', label: 'Nastaveni', icon: Settings },
 ];

--- a/apps/garden_fe/src/hooks/useChartData.ts
+++ b/apps/garden_fe/src/hooks/useChartData.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { sensorReadingService } from '@/services/sensorReading.service';
+import type { SensorReading } from '@/types/api';
+
+export type TimeRange = '24h' | '7d' | '30d' | 'custom';
+
+const RANGE_CONFIG: Record<Exclude<TimeRange, 'custom'>, { hours: number; limit: number }> = {
+  '24h': { hours: 24, limit: 500 },
+  '7d': { hours: 7 * 24, limit: 1000 },
+  '30d': { hours: 30 * 24, limit: 2000 },
+};
+
+export function useChartData(
+  roomId: string | null,
+  range: TimeRange,
+  customFrom?: string,
+  customTo?: string
+) {
+  const [data, setData] = useState<SensorReading[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!roomId) {
+      setData([]);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setError(null);
+      let from: string;
+      let to: string | undefined;
+      let limit: number;
+
+      if (range === 'custom') {
+        from = customFrom ? new Date(customFrom).toISOString() : new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        to = customTo ? new Date(customTo + 'T23:59:59').toISOString() : undefined;
+        limit = 2000;
+      } else {
+        const config = RANGE_CONFIG[range];
+        from = new Date(Date.now() - config.hours * 60 * 60 * 1000).toISOString();
+        to = undefined;
+        limit = config.limit;
+      }
+
+      const readings = await sensorReadingService.getByRoom(roomId, from, to, limit);
+      setData(readings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Nepodařilo se načíst data');
+    } finally {
+      setLoading(false);
+    }
+  }, [roomId, range, customFrom, customTo]);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchData();
+    const interval = setInterval(fetchData, 60000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
+}


### PR DESCRIPTION
Add a new /dashboard/grafy page for viewing historical IoT sensor data (temperature, humidity, soil moisture, water level) with room selection and configurable time ranges (24h, 7d, 30d, custom).