### PR TITLE
feat: herb management with image uploads and plant types

### DIFF
--- a/apps/garden_be/src/herb/dtos/herbRequest.dto.ts
+++ b/apps/garden_be/src/herb/dtos/herbRequest.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
     IsDate,
+    IsIn,
     IsNumber,
     IsOptional,
     IsString,
@@ -9,6 +10,7 @@ import {
     IsObject,
 } from 'class-validator';
 import { GrowConditions } from '../../growConditions/entity/growConditions.entity';
+import { PLANT_TYPES, PlantType } from '../../utils/const';
 
 export class HerbRequestDto {
     @ApiProperty({ description: 'Name of the herb', example: 'Basil' })
@@ -45,6 +47,16 @@ export class HerbRequestDto {
     @IsOptional()
     @IsDate()
     lastWatering?: Date;
+
+    @ApiProperty({
+        description: 'Plant type',
+        example: 'herb',
+        enum: PLANT_TYPES,
+        required: false,
+    })
+    @IsOptional()
+    @IsIn(PLANT_TYPES)
+    plantType?: PlantType;
 
     @ApiProperty({
         description: 'Grow Conditions of herb',

--- a/apps/garden_be/src/herb/dtos/herbResponse.dto.ts
+++ b/apps/garden_be/src/herb/dtos/herbResponse.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { PlantType } from '../../utils/const';
 
 export class HerbResponseDto {
     @ApiProperty({
@@ -42,6 +43,21 @@ export class HerbResponseDto {
         example: '2026-01-09T12:00:00Z',
     })
     lastWatering: Date;
+
+    @ApiProperty({
+        description: 'URL of the herb image',
+        example: '/uploads/herbs/1234567890.jpg',
+        required: false,
+        nullable: true,
+    })
+    imageUrl: string | null;
+
+    @ApiProperty({
+        description: 'Type of plant',
+        example: 'herb',
+        enum: ['herb', 'flower', 'vegetable', 'fruit', 'other'],
+    })
+    plantType: PlantType;
 
     @ApiProperty({
         description: 'ID of the room where the herb is located',

--- a/apps/garden_be/src/herb/entity/herb.entity.ts
+++ b/apps/garden_be/src/herb/entity/herb.entity.ts
@@ -11,6 +11,7 @@ import { History } from '../../history/entity/history.entity';
 import { Room } from '../../room/entity/room.entity';
 import { Notification } from '../../notification/entity/notification.entity';
 import { GrowConditions } from '../../growConditions/entity/growConditions.entity';
+import { PLANT_TYPES, PlantType } from '../../utils/const';
 
 @Entity({ name: 'herb' })
 export class Herb extends BaseEntity {
@@ -31,6 +32,16 @@ export class Herb extends BaseEntity {
 
     @Column({ type: 'timestamptz' })
     lastWatering!: Date;
+
+    @Column({ type: 'varchar', nullable: true })
+    imageUrl!: string | null;
+
+    @Column({
+        type: 'enum',
+        enum: PLANT_TYPES,
+        default: 'herb',
+    })
+    plantType!: PlantType;
 
     @OneToMany(() => History, (history) => history.herb)
     histories!: History[];

--- a/apps/garden_be/src/herb/herb.controller.ts
+++ b/apps/garden_be/src/herb/herb.controller.ts
@@ -6,7 +6,12 @@ import {
     Param,
     Post,
     Put,
+    UploadedFile,
+    UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { extname } from 'path';
 import { HerbService } from './services/herb.service';
 import { HerbResponseDto } from './dtos/herbResponse.dto';
 import { toHerbResponseDto } from './herb.mapper';
@@ -46,5 +51,37 @@ export class HerbController {
     @Delete(':id')
     async delete(@Param('id') id: string): Promise<void> {
         await this.herbService.delete({ id } as any);
+    }
+
+    @Post(':id/image')
+    @UseInterceptors(
+        FileInterceptor('image', {
+            storage: diskStorage({
+                destination: './uploads/herbs',
+                filename: (_req, file, cb) => {
+                    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+                    cb(null, `${uniqueSuffix}${extname(file.originalname)}`);
+                },
+            }),
+            fileFilter: (_req, file, cb) => {
+                if (!file.mimetype.match(/\/(jpg|jpeg|png|gif|webp)$/)) {
+                    cb(new Error('Only image files are allowed'), false);
+                    return;
+                }
+                cb(null, true);
+            },
+            limits: { fileSize: 5 * 1024 * 1024 },
+        })
+    )
+    async uploadImage(
+        @Param('id') id: string,
+        @UploadedFile() file: Express.Multer.File
+    ): Promise<HerbResponseDto> {
+        const imageUrl = `/uploads/herbs/${file.filename}`;
+        const herb = await this.herbService.update(
+            { id } as any,
+            { imageUrl } as any
+        );
+        return toHerbResponseDto(herb);
     }
 }

--- a/apps/garden_be/src/herb/herb.mapper.ts
+++ b/apps/garden_be/src/herb/herb.mapper.ts
@@ -9,10 +9,12 @@ export const toHerbResponseDto = (herb: Herb): HerbResponseDto => ({
     humidity: herb.humidity,
     soilMoisture: herb.soilMoisture,
     lastWatering: herb.lastWatering,
+    imageUrl: herb.imageUrl ?? null,
+    plantType: herb.plantType ?? 'herb',
     roomId: herb.room?.id,
     notificationIds: herb.notifications?.map((n) => n.id) ?? [],
     historyIds: herb.histories?.map((h) => h.id) ?? [],
-    growConditionId: herb.growConditions.id,
+    growConditionId: herb.growConditions?.id,
     createdAt: herb.createdAt,
     updatedAt: herb.updatedAt,
 });

--- a/apps/garden_be/src/infrastructure/database/migrations/1768062000000-AddHerbImageAndPlantType.js
+++ b/apps/garden_be/src/infrastructure/database/migrations/1768062000000-AddHerbImageAndPlantType.js
@@ -1,0 +1,15 @@
+module.exports = class AddHerbImageAndPlantType1768062000000 {
+    name = 'AddHerbImageAndPlantType1768062000000'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "herb" ADD "imageUrl" character varying`);
+        await queryRunner.query(`CREATE TYPE "public"."herb_plant_type_enum" AS ENUM('herb', 'flower', 'vegetable', 'fruit', 'other')`);
+        await queryRunner.query(`ALTER TABLE "herb" ADD "plantType" "public"."herb_plant_type_enum" NOT NULL DEFAULT 'herb'`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "herb" DROP COLUMN "plantType"`);
+        await queryRunner.query(`DROP TYPE "public"."herb_plant_type_enum"`);
+        await queryRunner.query(`ALTER TABLE "herb" DROP COLUMN "imageUrl"`);
+    }
+}

--- a/apps/garden_be/src/main.ts
+++ b/apps/garden_be/src/main.ts
@@ -1,11 +1,17 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 import { Logger } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { join } from 'path';
 
 async function bootstrap() {
-    const app = await NestFactory.create(AppModule);
+    const app = await NestFactory.create<NestExpressApplication>(AppModule);
     app.enableCors();
+
+    app.useStaticAssets(join(__dirname, '..', 'uploads'), {
+        prefix: '/uploads',
+    });
 
     const config = new DocumentBuilder()
         .setTitle('Garden API')

--- a/apps/garden_be/src/utils/const/index.ts
+++ b/apps/garden_be/src/utils/const/index.ts
@@ -30,3 +30,6 @@ export type LightStatus = (typeof LIGHT_STATUSES)[number];
 
 export const LIGHT_MODES = ['growth', 'bloom', 'off'] as const;
 export type LightMode = (typeof LIGHT_MODES)[number];
+
+export const PLANT_TYPES = ['herb', 'flower', 'vegetable', 'fruit', 'other'] as const;
+export type PlantType = (typeof PLANT_TYPES)[number];

--- a/apps/garden_fe/src/app/dashboard/herb/[id]/page.tsx
+++ b/apps/garden_fe/src/app/dashboard/herb/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import {
   ArrowLeft,
@@ -9,22 +9,61 @@ import {
   Thermometer,
   Droplets,
   CalendarDays,
+  Pencil,
+  Trash2,
+  ImagePlus,
 } from "lucide-react";
 import { herbService } from "@/services/herb.service";
 import { historyService } from "@/services/history.service";
 import { growConditionsService } from "@/services/growConditions.service";
-import type { Herb, History, GrowConditions } from "@/types/api";
+import type {
+  Herb,
+  History,
+  GrowConditions,
+  PlantType,
+  HerbUpdateRequest,
+} from "@/types/api";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { useToast } from "@/components/ui/toast";
 import { WateringHistoryChart } from "@/components/charts/WateringHistoryChart";
 import { HerbActions } from "@/components/herbs/HerbActions";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+const PLANT_TYPE_LABELS: Record<PlantType, string> = {
+  herb: "Bylinka",
+  flower: "Kvetina",
+  vegetable: "Zelenina",
+  fruit: "Ovoce",
+  other: "Ostatni",
+};
+
+const PLANT_TYPE_COLORS: Record<PlantType, string> = {
+  herb: "bg-green-100 text-green-800",
+  flower: "bg-pink-100 text-pink-800",
+  vegetable: "bg-orange-100 text-orange-800",
+  fruit: "bg-purple-100 text-purple-800",
+  other: "bg-gray-100 text-gray-800",
+};
 
 export default function HerbDetailPage() {
   const params = useParams();
   const router = useRouter();
   const id = params.id as string;
+  const { toast } = useToast();
 
   const [herb, setHerb] = useState<Herb | null>(null);
   const [history, setHistory] = useState<History[]>([]);
@@ -32,6 +71,24 @@ export default function HerbDetailPage() {
     null
   );
   const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+
+  // Edit dialog
+  const [editOpen, setEditOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editForm, setEditForm] = useState({
+    name: "",
+    description: "",
+    plantType: "herb" as PlantType,
+    temperature: 22,
+    humidity: 50,
+    soilMoisture: 40,
+  });
+
+  // Delete dialog
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const fetchData = useCallback(async () => {
     try {
@@ -73,11 +130,112 @@ export default function HerbDetailPage() {
     return () => clearInterval(interval);
   }, [fetchData]);
 
+  const openEdit = () => {
+    if (!herb) return;
+    setEditForm({
+      name: herb.name,
+      description: herb.description,
+      plantType: herb.plantType || "herb",
+      temperature: herb.temperature,
+      humidity: herb.humidity,
+      soilMoisture: herb.soilMoisture,
+    });
+    setEditOpen(true);
+  };
+
+  const handleEdit = async () => {
+    if (!herb) return;
+    if (!editForm.name?.trim()) {
+      toast({
+        title: "Chyba",
+        description: "Zadejte nazev bylinky.",
+        variant: "error",
+      });
+      return;
+    }
+    try {
+      setEditing(true);
+      const updateData: HerbUpdateRequest = {
+        name: editForm.name,
+        description: editForm.description,
+        temperature: editForm.temperature,
+        humidity: editForm.humidity,
+        soilMoisture: editForm.soilMoisture,
+        plantType: editForm.plantType,
+      };
+      await herbService.update(herb.id, updateData);
+      toast({
+        title: "Bylinka upravena",
+        description: `Bylinka "${editForm.name}" byla uspesne upravena.`,
+        variant: "success",
+      });
+      setEditOpen(false);
+      fetchData();
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se upravit bylinku.",
+        variant: "error",
+      });
+    } finally {
+      setEditing(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!herb) return;
+    try {
+      setDeleting(true);
+      await herbService.remove(herb.id);
+      toast({
+        title: "Bylinka smazana",
+        description: `Bylinka "${herb.name}" byla smazana.`,
+        variant: "success",
+      });
+      router.push("/dashboard/herbs");
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se smazat bylinku.",
+        variant: "error",
+      });
+    } finally {
+      setDeleting(false);
+      setDeleteOpen(false);
+    }
+  };
+
+  const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file || !herb) return;
+    try {
+      setUploading(true);
+      await herbService.uploadImage(herb.id, file);
+      toast({
+        title: "Obrazek nahran",
+        description: "Obrazek bylinky byl uspesne nahran.",
+        variant: "success",
+      });
+      fetchData();
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se nahrat obrazek.",
+        variant: "error",
+      });
+    } finally {
+      setUploading(false);
+      if (imageInputRef.current) {
+        imageInputRef.current.value = "";
+      }
+    }
+  };
+
   if (loading) {
     return (
       <div className="space-y-6">
         <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-32" />
+        <Skeleton className="h-48" />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Skeleton className="h-24" />
           <Skeleton className="h-24" />
@@ -110,6 +268,8 @@ export default function HerbDetailPage() {
     amount: h.amountWater,
   }));
 
+  const plantType = herb.plantType || "herb";
+
   return (
     <div className="space-y-6">
       {/* Back button */}
@@ -118,16 +278,204 @@ export default function HerbDetailPage() {
         Zpet
       </Button>
 
-      {/* Header */}
-      <div className="flex items-center gap-4">
-        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-green-100">
-          <Leaf className="h-8 w-8 text-green-600" />
+      {/* Header with image */}
+      <div className="flex flex-col sm:flex-row gap-6">
+        {/* Image */}
+        <div className="relative h-48 w-48 shrink-0 rounded-2xl bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center overflow-hidden">
+          {herb.imageUrl ? (
+            <img
+              src={`${API_URL}${herb.imageUrl}`}
+              alt={herb.name}
+              className="h-full w-full object-cover rounded-2xl"
+            />
+          ) : (
+            <Leaf className="h-16 w-16 text-green-200" />
+          )}
         </div>
-        <div>
-          <h1 className="text-2xl font-bold">{herb.name}</h1>
-          <p className="text-muted-foreground">{herb.description}</p>
+
+        <div className="flex flex-col justify-between">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="text-2xl font-bold">{herb.name}</h1>
+              <Badge
+                variant="secondary"
+                className={PLANT_TYPE_COLORS[plantType]}
+              >
+                {PLANT_TYPE_LABELS[plantType]}
+              </Badge>
+            </div>
+            <p className="text-muted-foreground">{herb.description}</p>
+          </div>
+
+          <div className="flex items-center gap-2 mt-4">
+            <Button variant="outline" size="sm" onClick={openEdit}>
+              <Pencil className="h-4 w-4 mr-1" />
+              Upravit
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-600 hover:text-red-700"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="h-4 w-4 mr-1" />
+              Smazat
+            </Button>
+            <div>
+              <input
+                ref={imageInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                className="hidden"
+                onChange={handleImageUpload}
+              />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => imageInputRef.current?.click()}
+                disabled={uploading}
+              >
+                <ImagePlus className="h-4 w-4 mr-1" />
+                {uploading ? "Nahravam..." : "Nahrat obrazek"}
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
+
+      {/* Edit dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Upravit bylinku</DialogTitle>
+            <DialogDescription>Upravte udaje bylinky</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-name">Nazev</Label>
+              <Input
+                id="edit-name"
+                value={editForm.name}
+                onChange={(e) =>
+                  setEditForm((prev) => ({ ...prev, name: e.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-description">Popis</Label>
+              <textarea
+                id="edit-description"
+                value={editForm.description}
+                onChange={(e) =>
+                  setEditForm((prev) => ({
+                    ...prev,
+                    description: e.target.value,
+                  }))
+                }
+                className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-plantType">Typ rostliny</Label>
+              <select
+                id="edit-plantType"
+                value={editForm.plantType}
+                onChange={(e) =>
+                  setEditForm((prev) => ({
+                    ...prev,
+                    plantType: e.target.value as PlantType,
+                  }))
+                }
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <option value="herb">Bylinka</option>
+                <option value="flower">Kvetina</option>
+                <option value="vegetable">Zelenina</option>
+                <option value="fruit">Ovoce</option>
+                <option value="other">Ostatni</option>
+              </select>
+            </div>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="edit-temp">Teplota (°C)</Label>
+                <Input
+                  id="edit-temp"
+                  type="number"
+                  value={editForm.temperature}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      temperature: Number(e.target.value),
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-humidity">Vlhkost (%)</Label>
+                <Input
+                  id="edit-humidity"
+                  type="number"
+                  value={editForm.humidity}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      humidity: Number(e.target.value),
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="edit-soil">Vlhkost pudy (%)</Label>
+                <Input
+                  id="edit-soil"
+                  type="number"
+                  value={editForm.soilMoisture}
+                  onChange={(e) =>
+                    setEditForm((prev) => ({
+                      ...prev,
+                      soilMoisture: Number(e.target.value),
+                    }))
+                  }
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>
+              Zrusit
+            </Button>
+            <Button onClick={handleEdit} disabled={editing}>
+              {editing ? "Ukladam..." : "Ulozit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Smazat bylinku</DialogTitle>
+            <DialogDescription>
+              Opravdu chcete smazat bylinku &quot;{herb.name}&quot;? Tato akce
+              je nevratna.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              Zrusit
+            </Button>
+            <Button
+              variant="default"
+              className="bg-red-600 hover:bg-red-700"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Mazam..." : "Smazat"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Current readings cards */}
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -264,7 +612,7 @@ export default function HerbDetailPage() {
                       <td className="py-2 pr-4">{h.amountWater} ml</td>
                       <td className="py-2 pr-4">{h.temperature}°C</td>
                       <td className="py-2 text-muted-foreground">
-                        {h.notes || "—"}
+                        {h.notes || "\u2014"}
                       </td>
                     </tr>
                   ))}

--- a/apps/garden_fe/src/app/dashboard/herbs/page.tsx
+++ b/apps/garden_fe/src/app/dashboard/herbs/page.tsx
@@ -1,0 +1,629 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Plus,
+  Leaf,
+  Thermometer,
+  Droplets,
+  Droplet,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  ImagePlus,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { useHerbs } from "@/hooks/useHerbs";
+import { useRooms } from "@/hooks/useRooms";
+import { herbService } from "@/services/herb.service";
+import { useToast } from "@/components/ui/toast";
+import type { Herb, HerbCreateRequest, HerbUpdateRequest, PlantType } from "@/types/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+const PLANT_TYPE_LABELS: Record<PlantType, string> = {
+  herb: "Bylinka",
+  flower: "Kvetina",
+  vegetable: "Zelenina",
+  fruit: "Ovoce",
+  other: "Ostatni",
+};
+
+const PLANT_TYPE_COLORS: Record<PlantType, string> = {
+  herb: "bg-green-100 text-green-800",
+  flower: "bg-pink-100 text-pink-800",
+  vegetable: "bg-orange-100 text-orange-800",
+  fruit: "bg-purple-100 text-purple-800",
+  other: "bg-gray-100 text-gray-800",
+};
+
+function getStatus(herb: Herb): { color: string; label: string } {
+  if (herb.soilMoisture < 20 || herb.temperature > 35 || herb.temperature < 5) {
+    return { color: "bg-red-500", label: "Kriticke" };
+  }
+  if (herb.soilMoisture < 40 || herb.temperature > 30 || herb.temperature < 10) {
+    return { color: "bg-yellow-500", label: "Varovani" };
+  }
+  return { color: "bg-green-500", label: "V poradku" };
+}
+
+interface HerbFormData {
+  name: string;
+  description: string;
+  plantType: PlantType;
+  roomId: string;
+  temperature: number;
+  humidity: number;
+  soilMoisture: number;
+}
+
+const defaultFormData: HerbFormData = {
+  name: "",
+  description: "",
+  plantType: "herb",
+  roomId: "",
+  temperature: 22,
+  humidity: 50,
+  soilMoisture: 40,
+};
+
+function HerbFormFields({
+  formData,
+  setFormData,
+  rooms,
+}: {
+  formData: HerbFormData;
+  setFormData: (updater: (prev: HerbFormData) => HerbFormData) => void;
+  rooms: { id: string; name: string }[];
+}) {
+  return (
+    <div className="space-y-4 py-4">
+      <div className="space-y-2">
+        <Label htmlFor="herb-name">Nazev</Label>
+        <Input
+          id="herb-name"
+          value={formData.name}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, name: e.target.value }))
+          }
+          placeholder="Nazev bylinky"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="herb-description">Popis</Label>
+        <textarea
+          id="herb-description"
+          value={formData.description}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, description: e.target.value }))
+          }
+          placeholder="Popis bylinky"
+          className="flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="herb-plantType">Typ rostliny</Label>
+          <select
+            id="herb-plantType"
+            value={formData.plantType}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                plantType: e.target.value as PlantType,
+              }))
+            }
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="herb">Bylinka</option>
+            <option value="flower">Kvetina</option>
+            <option value="vegetable">Zelenina</option>
+            <option value="fruit">Ovoce</option>
+            <option value="other">Ostatni</option>
+          </select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="herb-room">Mistnost</Label>
+          <select
+            id="herb-room"
+            value={formData.roomId}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, roomId: e.target.value }))
+            }
+            className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <option value="">Vyberte mistnost</option>
+            {rooms.map((room) => (
+              <option key={room.id} value={room.id}>
+                {room.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="herb-temp">Teplota (°C)</Label>
+          <Input
+            id="herb-temp"
+            type="number"
+            value={formData.temperature}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                temperature: Number(e.target.value),
+              }))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="herb-humidity">Vlhkost (%)</Label>
+          <Input
+            id="herb-humidity"
+            type="number"
+            value={formData.humidity}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                humidity: Number(e.target.value),
+              }))
+            }
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="herb-soil">Vlhkost pudy (%)</Label>
+          <Input
+            id="herb-soil"
+            type="number"
+            value={formData.soilMoisture}
+            onChange={(e) =>
+              setFormData((prev) => ({
+                ...prev,
+                soilMoisture: Number(e.target.value),
+              }))
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function HerbsPage() {
+  const router = useRouter();
+  const { data: herbs, loading, refetch } = useHerbs();
+  const { data: rooms } = useRooms();
+  const { toast } = useToast();
+
+  // Create dialog
+  const [createOpen, setCreateOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createForm, setCreateForm] = useState<HerbFormData>({
+    ...defaultFormData,
+  });
+  const [createImage, setCreateImage] = useState<File | null>(null);
+  const createImageRef = useRef<HTMLInputElement>(null);
+
+  // Edit dialog
+  const [editOpen, setEditOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editingHerb, setEditingHerb] = useState<Herb | null>(null);
+  const [editForm, setEditForm] = useState<HerbFormData>({ ...defaultFormData });
+
+  // Delete dialog
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deletingHerb, setDeletingHerb] = useState<Herb | null>(null);
+
+  const handleCreate = async () => {
+    if (!createForm.name.trim()) {
+      toast({
+        title: "Chyba",
+        description: "Zadejte nazev bylinky.",
+        variant: "error",
+      });
+      return;
+    }
+    if (!createForm.roomId) {
+      toast({
+        title: "Chyba",
+        description: "Vyberte mistnost.",
+        variant: "error",
+      });
+      return;
+    }
+    try {
+      setCreating(true);
+      const requestData: HerbCreateRequest = {
+        name: createForm.name,
+        description: createForm.description,
+        temperature: createForm.temperature,
+        humidity: createForm.humidity,
+        soilMoisture: createForm.soilMoisture,
+        lastWatering: new Date().toISOString(),
+        plantType: createForm.plantType,
+        roomId: createForm.roomId,
+        growConditionId: "",
+      };
+      const created = await herbService.create(requestData);
+
+      if (createImage) {
+        await herbService.uploadImage(created.id, createImage);
+      }
+
+      toast({
+        title: "Bylinka vytvorena",
+        description: `Bylinka "${createForm.name}" byla uspesne vytvorena.`,
+        variant: "success",
+      });
+      setCreateOpen(false);
+      setCreateForm({ ...defaultFormData });
+      setCreateImage(null);
+      refetch();
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se vytvorit bylinku.",
+        variant: "error",
+      });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const openEdit = (herb: Herb) => {
+    setEditingHerb(herb);
+    setEditForm({
+      name: herb.name,
+      description: herb.description,
+      plantType: herb.plantType || "herb",
+      roomId: herb.roomId || "",
+      temperature: herb.temperature,
+      humidity: herb.humidity,
+      soilMoisture: herb.soilMoisture,
+    });
+    setEditOpen(true);
+  };
+
+  const handleEdit = async () => {
+    if (!editingHerb) return;
+    if (!editForm.name?.trim()) {
+      toast({
+        title: "Chyba",
+        description: "Zadejte nazev bylinky.",
+        variant: "error",
+      });
+      return;
+    }
+    try {
+      setEditing(true);
+      const updateData: HerbUpdateRequest = {
+        name: editForm.name,
+        description: editForm.description,
+        temperature: editForm.temperature,
+        humidity: editForm.humidity,
+        soilMoisture: editForm.soilMoisture,
+        plantType: editForm.plantType,
+        roomId: editForm.roomId || undefined,
+      };
+      await herbService.update(editingHerb.id, updateData);
+      toast({
+        title: "Bylinka upravena",
+        description: `Bylinka "${editForm.name}" byla uspesne upravena.`,
+        variant: "success",
+      });
+      setEditOpen(false);
+      setEditingHerb(null);
+      refetch();
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se upravit bylinku.",
+        variant: "error",
+      });
+    } finally {
+      setEditing(false);
+    }
+  };
+
+  const openDelete = (herb: Herb) => {
+    setDeletingHerb(herb);
+    setDeleteOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deletingHerb) return;
+    try {
+      setDeleting(true);
+      await herbService.remove(deletingHerb.id);
+      toast({
+        title: "Bylinka smazana",
+        description: `Bylinka "${deletingHerb.name}" byla smazana.`,
+        variant: "success",
+      });
+      setDeleteOpen(false);
+      setDeletingHerb(null);
+      refetch();
+    } catch {
+      toast({
+        title: "Chyba",
+        description: "Nepodarilo se smazat bylinku.",
+        variant: "error",
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const roomMap = Object.fromEntries(rooms.map((r) => [r.id, r.name]));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Bylinky</h1>
+        <Button onClick={() => setCreateOpen(true)}>
+          <Plus className="h-4 w-4 mr-2" />
+          Pridat bylinku
+        </Button>
+      </div>
+
+      {/* Create dialog */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Nova bylinka</DialogTitle>
+            <DialogDescription>
+              Vyplnte udaje pro novou bylinku
+            </DialogDescription>
+          </DialogHeader>
+          <HerbFormFields
+            formData={createForm}
+            setFormData={setCreateForm}
+            rooms={rooms}
+          />
+          <div className="space-y-2">
+            <Label>Obrazek</Label>
+            <div className="flex items-center gap-2">
+              <input
+                ref={createImageRef}
+                type="file"
+                accept="image/jpeg,image/png,image/gif,image/webp"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) setCreateImage(file);
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => createImageRef.current?.click()}
+              >
+                <ImagePlus className="h-4 w-4 mr-2" />
+                {createImage ? createImage.name : "Vybrat obrazek"}
+              </Button>
+              {createImage && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setCreateImage(null)}
+                >
+                  Odebrat
+                </Button>
+              )}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setCreateOpen(false);
+                setCreateForm({ ...defaultFormData });
+                setCreateImage(null);
+              }}
+            >
+              Zrusit
+            </Button>
+            <Button onClick={handleCreate} disabled={creating}>
+              {creating ? "Vytvarim..." : "Vytvorit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Upravit bylinku</DialogTitle>
+            <DialogDescription>Upravte udaje bylinky</DialogDescription>
+          </DialogHeader>
+          <HerbFormFields
+            formData={editForm}
+            setFormData={setEditForm}
+            rooms={rooms}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditOpen(false)}>
+              Zrusit
+            </Button>
+            <Button onClick={handleEdit} disabled={editing}>
+              {editing ? "Ukladam..." : "Ulozit"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Smazat bylinku</DialogTitle>
+            <DialogDescription>
+              Opravdu chcete smazat bylinku &quot;{deletingHerb?.name}&quot;?
+              Tato akce je nevratna.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteOpen(false)}>
+              Zrusit
+            </Button>
+            <Button
+              variant="default"
+              className="bg-red-600 hover:bg-red-700"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? "Mazam..." : "Smazat"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {loading ? (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-48" />
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : herbs.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-muted-foreground">
+          <Leaf className="h-12 w-12 mb-4 text-green-300" />
+          <p className="text-lg">Zatim nemate zadne bylinky</p>
+          <p className="text-sm">
+            Kliknete na &quot;Pridat bylinku&quot; pro vytvoreni prvni bylinky.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {herbs.map((herb) => {
+            const status = getStatus(herb);
+            return (
+              <Card
+                key={herb.id}
+                className="relative cursor-pointer transition-shadow hover:shadow-lg overflow-hidden"
+                onClick={() => router.push(`/dashboard/herb/${herb.id}`)}
+              >
+                {/* Image or placeholder */}
+                <div className="h-40 bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center overflow-hidden">
+                  {herb.imageUrl ? (
+                    <img
+                      src={`${API_URL}${herb.imageUrl}`}
+                      alt={herb.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <Leaf className="h-16 w-16 text-green-200" />
+                  )}
+                </div>
+
+                {/* Dropdown menu */}
+                <div
+                  className="absolute right-2 top-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <DropdownMenu>
+                    <DropdownMenuTrigger className="rounded-md p-1 bg-white/80 hover:bg-white shadow-sm">
+                      <MoreVertical className="h-4 w-4 text-gray-500" />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem onClick={() => openEdit(herb)}>
+                        <Pencil className="h-4 w-4" />
+                        Upravit
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-red-600 hover:!text-red-600"
+                        onClick={() => openDelete(herb)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Smazat
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-lg">{herb.name}</CardTitle>
+                    <div className="flex items-center gap-2">
+                      <Badge
+                        variant="secondary"
+                        className={
+                          PLANT_TYPE_COLORS[herb.plantType || "herb"]
+                        }
+                      >
+                        {PLANT_TYPE_LABELS[herb.plantType || "herb"]}
+                      </Badge>
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <span
+                          className={`h-2.5 w-2.5 rounded-full ${status.color}`}
+                        />
+                        {status.label}
+                      </span>
+                    </div>
+                  </div>
+                  {herb.roomId && roomMap[herb.roomId] && (
+                    <CardDescription>{roomMap[herb.roomId]}</CardDescription>
+                  )}
+                </CardHeader>
+                <CardContent>
+                  <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Droplet className="h-4 w-4 text-blue-500" />
+                      {herb.soilMoisture}%
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Thermometer className="h-4 w-4 text-red-500" />
+                      {herb.temperature}°C
+                    </span>
+                    <span className="flex items-center gap-1">
+                      <Droplets className="h-4 w-4 text-cyan-500" />
+                      {herb.humidity}%
+                    </span>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/garden_fe/src/components/herbs/HerbCard.tsx
+++ b/apps/garden_fe/src/components/herbs/HerbCard.tsx
@@ -1,9 +1,28 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Thermometer, Droplets, Droplet } from "lucide-react";
+import { Thermometer, Droplets, Droplet, Leaf } from "lucide-react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import type { Herb } from "@/types/api";
+import { Badge } from "@/components/ui/badge";
+import type { Herb, PlantType } from "@/types/api";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+const PLANT_TYPE_LABELS: Record<PlantType, string> = {
+  herb: "Bylinka",
+  flower: "Kvetina",
+  vegetable: "Zelenina",
+  fruit: "Ovoce",
+  other: "Ostatni",
+};
+
+const PLANT_TYPE_COLORS: Record<PlantType, string> = {
+  herb: "bg-green-100 text-green-800",
+  flower: "bg-pink-100 text-pink-800",
+  vegetable: "bg-orange-100 text-orange-800",
+  fruit: "bg-purple-100 text-purple-800",
+  other: "bg-gray-100 text-gray-800",
+};
 
 interface HerbCardProps {
   herb: Herb;
@@ -22,19 +41,41 @@ function getStatus(herb: Herb): { color: string; label: string } {
 export function HerbCard({ herb }: HerbCardProps) {
   const router = useRouter();
   const status = getStatus(herb);
+  const plantType = herb.plantType || "herb";
 
   return (
     <Card
-      className="cursor-pointer transition-shadow hover:shadow-md"
+      className="cursor-pointer transition-shadow hover:shadow-md overflow-hidden"
       onClick={() => router.push(`/dashboard/herb/${herb.id}`)}
     >
+      {/* Image or placeholder */}
+      <div className="h-32 bg-gradient-to-br from-green-50 to-green-100 flex items-center justify-center overflow-hidden">
+        {herb.imageUrl ? (
+          <img
+            src={`${API_URL}${herb.imageUrl}`}
+            alt={herb.name}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <Leaf className="h-12 w-12 text-green-200" />
+        )}
+      </div>
+
       <CardHeader className="pb-2">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg">{herb.name}</CardTitle>
-          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span className={`h-2.5 w-2.5 rounded-full ${status.color}`} />
-            {status.label}
-          </span>
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className={PLANT_TYPE_COLORS[plantType]}
+            >
+              {PLANT_TYPE_LABELS[plantType]}
+            </Badge>
+            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className={`h-2.5 w-2.5 rounded-full ${status.color}`} />
+              {status.label}
+            </span>
+          </div>
         </div>
       </CardHeader>
       <CardContent>

--- a/apps/garden_fe/src/components/layout/Sidebar.tsx
+++ b/apps/garden_fe/src/components/layout/Sidebar.tsx
@@ -2,13 +2,14 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Home, BarChart3, Bell, Settings } from 'lucide-react';
+import { LayoutDashboard, Home, Leaf, BarChart3, Bell, Settings } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 
 const navItems = [
   { href: '/dashboard', label: 'Prehled', icon: LayoutDashboard },
   { href: '/dashboard/rooms', label: 'Mistnosti', icon: Home },
+  { href: '/dashboard/herbs', label: 'Bylinky', icon: Leaf },
   { href: '/dashboard/grafy', label: 'Grafy', icon: BarChart3 },
   { href: '/dashboard/notifications', label: 'Upozorneni', icon: Bell },
   { href: '/dashboard/settings', label: 'Nastaveni', icon: Settings },

--- a/apps/garden_fe/src/services/herb.service.ts
+++ b/apps/garden_fe/src/services/herb.service.ts
@@ -25,4 +25,13 @@ export const herbService = {
   async remove(id: string): Promise<void> {
     await api.delete(`/herb/${id}`);
   },
+
+  async uploadImage(herbId: string, file: File): Promise<Herb> {
+    const formData = new FormData();
+    formData.append('image', file);
+    const response = await api.post<Herb>(`/herb/${herbId}/image`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+    return response.data;
+  },
 };

--- a/apps/garden_fe/src/types/api.ts
+++ b/apps/garden_fe/src/types/api.ts
@@ -33,6 +33,8 @@ export interface Herb {
   humidity: number;
   soilMoisture: number;
   lastWatering: string;
+  imageUrl?: string | null;
+  plantType: PlantType;
   roomId?: string;
   notificationIds: string[];
   historyIds: string[];
@@ -64,6 +66,8 @@ export interface Notification {
   createdAt: string;
   updatedAt: string;
 }
+
+export type PlantType = 'herb' | 'flower' | 'vegetable' | 'fruit' | 'other';
 
 export type SoilType = 'sandy' | 'loamy' | 'clay' | 'other';
 
@@ -128,6 +132,7 @@ export interface HerbCreateRequest {
   humidity: number;
   soilMoisture: number;
   lastWatering: string;
+  plantType?: PlantType;
   roomId?: string;
   growConditionId: string;
 }
@@ -139,6 +144,7 @@ export interface HerbUpdateRequest {
   humidity?: number;
   soilMoisture?: number;
   lastWatering?: string;
+  plantType?: PlantType;
   roomId?: string;
   growConditionId?: string;
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@swc/cli": "~0.6.0",
         "@swc/core": "~1.5.7",
         "@swc/helpers": "~0.5.11",
+        "@types/multer": "^2.1.0",
         "@types/node": "18.16.9",
         "@types/react": "19.0.0",
         "@types/react-dom": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@swc/helpers':
         specifier: ~0.5.11
         version: 0.5.18
+      '@types/multer':
+        specifier: ^2.1.0
+        version: 2.1.0
       '@types/node':
         specifier: 18.16.9
         version: 18.16.9
@@ -3327,6 +3330,9 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/multer@2.1.0':
+    resolution: {integrity: sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==}
 
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
@@ -12637,6 +12643,10 @@ snapshots:
   '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
+
+  '@types/multer@2.1.0':
+    dependencies:
+      '@types/express': 4.17.25
 
   '@types/node-forge@1.3.14':
     dependencies:


### PR DESCRIPTION
- Add plantType enum (herb, flower, vegetable, fruit, other) to Herb entity
- Add imageUrl field for herb photos with multer upload endpoint (5MB, images only)
- Add static file serving for uploaded images
- Add /dashboard/herbs page with full CRUD (create, edit, delete dialogs)
- Add image upload support on create and herb detail page
- Update HerbCard with image display, plant type badge
- Update herb detail page with edit/delete, image upload
- Add Bylinky nav item to sidebar
- Add DB migration for new columns